### PR TITLE
update dependency on flake to 0.4.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
                  [net.jodah/lyra "0.5.2"]
                  [com.rabbitmq/amqp-client "3.6.1"]
                  [peripheral "0.5.2"]
-                 [flake "0.3.2"]
+                 [flake "0.4.1"]
                  [manifold "0.1.4"]
                  [potemkin "0.4.3"]]
   :profiles {:dev

--- a/src/kithara/utils.clj
+++ b/src/kithara/utils.clj
@@ -1,5 +1,5 @@
 (ns ^:no-doc kithara.utils
-  (:require [flake.core :as flake]
+  (:require [flake.core :as flake :refer [flake->bigint]]
             [flake.utils :refer [base62-encode]]))
 
 ;; ## Flake
@@ -10,7 +10,7 @@
 (defn random-string
   []
   @__flake-init__
-  (base62-encode (flake/generate)))
+  (base62-encode (flake->bigint (flake/generate!))))
 
 ;; ## Stringify
 


### PR DESCRIPTION
We were having some issues with null devices and flake leading to a `NullPointerException` at require time, so here is an update for the dependency. (whereas in flake > 0.4.0 it now filters these out)

(also advise if theres a code-style problem or anything), thanks :)
