### PR TITLE
update flake

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
                  [net.jodah/lyra "0.5.2"]
                  [com.rabbitmq/amqp-client "3.6.1"]
                  [peripheral "0.5.2"]
-                 [flake "0.4.1"]
+                 [flake "0.4.3"]
                  [manifold "0.1.4"]
                  [potemkin "0.4.3"]]
   :profiles {:dev


### PR DESCRIPTION
Flake 0.4.3 fixes a potential bug where the base62 conversation function could produce numbers which sorted improperly.
