### PR TITLE
Update to flake 4.4

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
                  [net.jodah/lyra "0.5.2"]
                  [com.rabbitmq/amqp-client "3.6.1"]
                  [peripheral "0.5.2"]
-                 [flake "0.4.3"]
+                 [flake "0.4.4"]
                  [manifold "0.1.4"]
                  [potemkin "0.4.3"]]
   :profiles {:dev


### PR DESCRIPTION
We've experienced some issues with version 0.4.3 of flake (sometimes the file which stores the timestamp would end up empty) https://github.com/maxcountryman/flake/commit/75672ace562d0847a8d5cd8099df9bad1117d78d

I've run kithara tests locally and all appears to be working fine 👍 
