### PR TITLE
Fix IllegalArgumentException in kithara.rabbitmq.queue/get

### DIFF
--- a/src/kithara/rabbitmq/queue.clj
+++ b/src/kithara/rabbitmq/queue.clj
@@ -35,7 +35,7 @@
     (message/build
       channel
       (.getEnvelope r)
-      (.getProperties r)
+      (.getProps r)
       (.getBody r)
       opts)))
 


### PR DESCRIPTION
Calling `kithara.rabbitmq.queue/get` raises a
`java.lang.IllegalArgumentException` with the following message:

   No matching field found: getProperties for class
   com.rabbitmq.client.GetResponse

The `GetResponse` class does not have a `getProperties` method, it is
called `getProps`. This PR fixes the problem. See also:

https://www.rabbitmq.com/releases/rabbitmq-java-client/current-javadoc/com/rabbitmq/client/GetResponse.html#getProps--